### PR TITLE
Made empty text field show all items without changing focus.

### DIFF
--- a/src/combo-box.component.ts
+++ b/src/combo-box.component.ts
@@ -203,10 +203,6 @@ export class ComboBoxComponent implements ControlValueAccessor, OnInit {
         clearTimeout(this._aheadTimer);
         if (!this._currVal) {
             this.sendModelChange(null);
-            if (!this.remote && this.localFilter) {
-                this.data = this._initialData;
-            }
-            return;
         }
 
         this._aheadTimer = setTimeout(this.loadData.bind(this), this.typeAheadDelay);


### PR DESCRIPTION
If you cleared the whole text field, the list would not be filled with all items because of a wrong check condition. This removes the ambigous code block that caused this behavoiur.