### PR TITLE
Fixed not resetting focus on field blur keeping _hasFocus set to true…

### DIFF
--- a/src/combo-box.component.ts
+++ b/src/combo-box.component.ts
@@ -282,11 +282,11 @@ export class ComboBoxComponent implements ControlValueAccessor, OnInit {
     }
 
     onFieldBlur(event: FocusEvent) {
+        this._hasFocus = false;
         if (this._noBlur) {
             return;
         }
 
-        this._hasFocus = false;
         this.onBlur.emit(event);
         // timeout for hide to catch click event on list :-(
         setTimeout(() => {


### PR DESCRIPTION
… and therefore causing the combo box list to stay open at the wrong time.