### PR TITLE
Implemented custom validation in the Angular control

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,9 @@ delay before triggering search.
 `inputClass: string = 'form-control';`  
 class to apply to the inner input field
 
+`inputErrorClass: string;`
+class to append to the inner input field if the control becomes invalid
+
 `loadingIconClass: string = 'loader';`  
 class to apply to the loading icon element
 

--- a/README.md
+++ b/README.md
@@ -58,9 +58,6 @@ delay before triggering search.
 `inputClass: string = 'form-control';`  
 class to apply to the inner input field
 
-`inputErrorClass: string;`
-class to append to the inner input field if the control becomes invalid
-
 `loadingIconClass: string = 'loader';`  
 class to apply to the loading icon element
 

--- a/src/combo-box.component.ts
+++ b/src/combo-box.component.ts
@@ -7,7 +7,7 @@ import {AbstractControl, ControlValueAccessor, NG_VALIDATORS, NG_VALUE_ACCESSOR,
     selector: 'combo-box',
     template: `
         <div class="field-wrap">
-            <input #inputField class="{{inputClass}} {{valid ? '' : inputErrorClass}}" type="text"
+            <input #inputField class="{{inputClass}}" type="text"
                    [(ngModel)]="currVal"
                    (keydown)="onKeyDown($event)"
                    (blur)="onFieldBlur($event)"
@@ -121,8 +121,6 @@ export class ComboBoxComponent implements ControlValueAccessor, OnInit, Validato
     typeAheadDelay: number = 500;
     @Input()
     inputClass: string = 'form-control';
-    @Input()
-    inputErrorClass: string;
     @Input()
     loadingIconClass: string = 'loader';
     @Input()

--- a/src/combo-box.component.ts
+++ b/src/combo-box.component.ts
@@ -149,7 +149,7 @@ export class ComboBoxComponent implements ControlValueAccessor, OnInit, Validato
 
     hideList: boolean = true;
     data: any[];
-    valid: boolean = true;
+    valid: boolean = false;
 
     private _loading: boolean = false;
     private _listDataSubscription: Subscription;


### PR DESCRIPTION
The combo-box will now validate whether the selected or typed value is a valid value (i.e. it matches to one of the items of the selection list). If it does, the control marks itself as valid, otherwise it becomes invalid.

A new input property has been introduced, the inputErrorClass to allow us format the input box when the control is marked as invalid.

This implementation works with both ngModel forms and Reactive Forms.

Note: The validation does not occur when remote data is being used. In that case, the control is always marked as invalid which is backwards compatible.
