### PR TITLE
Optionally display "No Matches" text in dropdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,9 @@ root element for list data (only first level at the moment)
 `disabledField: string = '';`
 member of data object which marks object as disabled (sets class and prevent selection)
 
+`noMatchesText: string = '';`
+text to appear when the input text does not match any item of the selection list.
+
 ### Events / Outputs
 
 `onQuery: EventEmitter<string>();`  

--- a/src/combo-box.component.ts
+++ b/src/combo-box.component.ts
@@ -19,6 +19,7 @@ import {ControlValueAccessor, NG_VALUE_ACCESSOR} from '@angular/forms';
             </div>
         
             <div class="list" *ngIf="data && !hideList" (mouseenter)="onMouseEnterList($event)" (mouseleave)="onMouseLeaveList($event)">
+                <div class="no-matches" *ngIf="noMatchesText && data.length == 0">{{noMatchesText}}</div>
                 <div *ngFor="let item of data;let index = index;"
                      [ngClass]="{'item': true, 'marked': isMarked(item), 'disabled': isDisabled(item)}"
                      (click)="onItemClick(index, item)">
@@ -43,6 +44,13 @@ import {ControlValueAccessor, NG_VALUE_ACCESSOR} from '@angular/forms';
             overflow: auto;
         }
         
+        .list .no-matches {
+            padding: 10px 20px;
+            cursor: default;
+            user-select: none;
+            font-style: italic;
+        }
+
         .list .item {
             padding: 10px 20px;
             cursor: pointer;
@@ -126,6 +134,8 @@ export class ComboBoxComponent implements ControlValueAccessor, OnInit {
     disabledField: string = null;
     @Input()
     editable: boolean = true;
+    @Input()
+    noMatchesText: string = '';
 
     @Output()
     onQuery = new EventEmitter<string>();


### PR DESCRIPTION
This is a usability change to indicate to the user that there are no matches.

When the user's input text does not match any item of the selection list, display a "No Mathces" text in the dropdown.