### PR TITLE
Suggested dropdown items were not matching user's input

### DIFF
--- a/src/combo-box.component.ts
+++ b/src/combo-box.component.ts
@@ -189,6 +189,9 @@ export class ComboBoxComponent implements ControlValueAccessor, OnInit {
             let data = <Object[]>value;
             this.data = this._initialData = data;
             this.loading = false;
+
+            // If the list data change, trigger a reprocessing.
+            this.loadData();
         }
     }
 


### PR DESCRIPTION
This fixes an issue when the user has started typing before the host component is able to provide the complete list of data. When the host component provides the list, then the provided list was not being reprocessed in order to match what the use had already typed.
