### PR TITLE
Added 'any' type to inputField ViewChild definition

### DIFF
--- a/src/combo-box.component.ts
+++ b/src/combo-box.component.ts
@@ -161,7 +161,7 @@ export class ComboBoxComponent implements ControlValueAccessor, OnInit {
     @Output()
     onInitValue = new EventEmitter<string>();
 
-    @ViewChild('inputField') _input;
+    @ViewChild('inputField') _input: any;
 
     hideList: boolean = true;
     data: any[];


### PR DESCRIPTION
Adding this type fixes an error thrown by the typescript `noImplicitAny` rule.