### PR TITLE
Updated rxjs import to remove /Rx

### DIFF
--- a/src/combo-box.component.ts
+++ b/src/combo-box.component.ts
@@ -1,5 +1,5 @@
 import { Component, OnInit, Input, Output, EventEmitter, forwardRef, ViewChild, ElementRef } from '@angular/core';
-import { Observable, Subscription } from 'rxjs/Rx';
+import { Observable, Subscription } from 'rxjs';
 import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
 
 @Component({


### PR DESCRIPTION
As of Angular 6 the /Rx is no longer needed